### PR TITLE
fix: make session hooks actually load and persist project memory

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -34,8 +34,9 @@ export function formatContext(profile: any, memories: any[]): string {
       "\nProject Knowledge:",
       ...memories.map((m: any) => {
         const time = m.updatedAt ? `[${formatRelativeTime(m.updatedAt)}] ` : "";
-        const content = m.memory ?? m.content ?? "";
-        return `- ${time}${content}`;
+        const body = m.memory ?? m.content ?? m.summary ?? "";
+        const label = m.title ? `${m.title}: ` : "";
+        return `- ${time}${label}${body}`;
       }),
     );
   }

--- a/src/hooks/session-end.ts
+++ b/src/hooks/session-end.ts
@@ -7,11 +7,33 @@ interface SessionEndInput {
   session_id: string;
   transcript_path?: string;
   reason?: string;
+  workspace_roots?: string[];
 }
 
 interface Turn {
   role: string;
-  content: unknown;
+  content?: unknown;
+  message?: unknown;
+}
+
+// Cursor transcripts store each turn as { role, message: { content: [{ type, text }] } }.
+// Older/other formats may use a flat string `content`. Extract plain text from either.
+function extractTurnText(turn: Turn): string {
+  if (typeof turn.content === "string") return turn.content;
+
+  const message = turn.message as { content?: unknown } | undefined;
+  const blocks = message?.content;
+  if (Array.isArray(blocks)) {
+    return blocks
+      .filter(
+        (b): b is { type: string; text: string } =>
+          !!b && typeof b === "object" && (b as { type?: unknown }).type === "text" &&
+          typeof (b as { text?: unknown }).text === "string",
+      )
+      .map((b) => b.text)
+      .join("\n");
+  }
+  return "";
 }
 
 function parseTranscript(text: string): Turn[] {
@@ -34,33 +56,43 @@ async function main() {
   const raw = await Bun.stdin.text();
   const input: SessionEndInput = JSON.parse(raw);
 
-  if (!input.transcript_path || input.reason !== "completed") return;
+  // Persist on any normal session end that produced a transcript. Cursor sends
+  // "completed" only rarely; real interactive sessions usually end with
+  // "user_close"/"window_close". Skip only sessions with no transcript or that
+  // ended abnormally ("aborted"/"error").
+  const NON_PERSISTABLE_REASONS = new Set(["aborted", "error"]);
+  if (!input.transcript_path || NON_PERSISTABLE_REASONS.has(input.reason ?? "")) return;
 
   const creds = loadCredentials();
   if (!creds) return;
 
-  const config = loadConfig();
+  // Cursor spawns this hook from ~/.cursor, so process.cwd() is NOT the
+  // workspace. Resolve config + project tag from workspace_roots[0] (as
+  // session-start does) so reads and writes target the same container.
+  const workspaceRoot = input.workspace_roots?.[0] || process.cwd();
+  const config = loadConfig(workspaceRoot);
   const apiKey = getApiKey(config);
   if (!apiKey) return;
 
   const fileContent = await Bun.file(input.transcript_path).text();
   const turns = parseTranscript(fileContent);
 
-  const relevant = turns.filter(
-    (t) => (t.role === "user" || t.role === "assistant") && typeof t.content === "string",
-  );
+  const relevant = turns
+    .filter((t) => t.role === "user" || t.role === "assistant")
+    .map((t) => ({ role: t.role, text: extractTurnText(t) }))
+    .filter((t) => t.text.length > 0);
   const userTurns = relevant.filter((t) => t.role === "user");
   if (userTurns.length < 2) return;
 
   let transcript = relevant
-    .map((t) => `${t.role === "user" ? "User" : "Assistant"}: ${t.content}`)
+    .map((t) => `${t.role === "user" ? "User" : "Assistant"}: ${t.text}`)
     .join("\n");
   if (transcript.length > 100_000) {
     transcript = transcript.slice(0, 100_000);
   }
 
   const userTag = getUserTag(config);
-  const projectTag = getProjectTag(process.cwd(), config);
+  const projectTag = getProjectTag(workspaceRoot, config);
   const content = `Cursor IDE session transcript:\n${transcript}`;
 
   await Promise.allSettled([

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -31,13 +31,16 @@ async function main() {
   const userTag = getUserTag(config);
   const projectTag = getProjectTag(input.workspace_roots[0] || process.cwd(), config);
 
+  // Use documents.list (recency-ordered) rather than search.memories: the v4
+  // search endpoint rejects the empty query we'd need to "list everything".
   const [profileResult, memoriesResult] = await Promise.allSettled([
     createClient(apiKey, userTag).profile({ containerTag: userTag }),
-    createClient(apiKey, projectTag).search.memories({ q: "", containerTag: projectTag, limit: 10 }),
+    createClient(apiKey, projectTag).documents.list({ containerTags: [projectTag], limit: 10 }),
   ]);
 
   const profile = profileResult.status === "fulfilled" ? profileResult.value.profile : null;
-  const memories = memoriesResult.status === "fulfilled" ? memoriesResult.value.results : [];
+  const memories =
+    memoriesResult.status === "fulfilled" ? (memoriesResult.value.memories ?? []) : [];
 
   const context = formatContext(profile, memories);
   if (!context) return ok();


### PR DESCRIPTION
Two related fixes so the Supermemory session hooks actually work end-to-end. Both are independent but ship together; commits are split so they can be reviewed separately.

---

## Commit 1 — `session-start`: load project memories via `documents.list`

The `sessionStart` hook fetched project memories with `search.memories({ q: "" })`, but the Supermemory v4 search endpoint rejects an empty query:

```json
{ "error": [{ "code": "too_small", "minimum": 1, "path": ["q"], "message": "Search query cannot be empty" }] }
```

Wrapped in `Promise.allSettled`, the rejection was swallowed -> `memories = []` -> the hook emitted a bare `{ "continue": true }` with no `additionalContext`. **Project knowledge was never loaded, for everyone.**

**Fix:** use `documents.list({ containerTags, limit })` (recency-ordered, no min-query constraint) -- the correct primitive for "N most recent project memories". Its items carry `summary`/`title` rather than `content`, so `formatContext` is extended to fall through `memory ?? content ?? summary` and prefix the title.

- `src/hooks/session-start.ts`, `src/context.ts`

---

## Commit 2 — `session-end`: persist real sessions to the correct container

`sessionEnd` never saved memory in normal use. Three bugs stacked, each hiding the next:

1. **Reason gate too strict.** Only persisted on `reason === "completed"`, but interactive sessions end with `user_close` / `window_close` (Cursor sends `completed` only rarely). Now persists on any end that produced a transcript except `aborted` / `error`.

2. **Transcript parsing extracted zero turns.** It read a flat `turn.content` string, but Cursor transcripts store `turn.message.content[]` blocks (`{ type: "text", text }`), so every turn was filtered out -> early return. Added `extractTurnText()` to read the block array (still falling back to a flat string for other formats).

3. **Reads and writes hit different containers.** `sessionEnd` derived its tag from `process.cwd()`, which is `~/.cursor` when Cursor spawns the hook -- not the workspace. So saves landed in a different container than `sessionStart` reads from. Now resolves config + tag from `workspace_roots[0]`, matching `sessionStart`.

- `src/hooks/session-end.ts`

---

## How I tested

- Reproduced the empty-query 400 directly against `POST /v4/search`.
- Instrumented both hooks and ran real Cursor session cycles (open chat -> exchange messages -> close):
  - **Before:** `sessionStart` injected no context; `sessionEnd` bailed at the reason gate, or parsed `relevantTurns: 0`, or wrote to a `~/.cursor`-derived tag the reader never queried.
  - **After:** `sessionStart` injects recent project memories; `sessionEnd` reaches the save call with `userSave`/`projectSave` both `fulfilled`, writing to the **same** container `sessionStart` reads. New records confirmed in the dashboard.
- Validated `extractTurnText()` against a real transcript: 273 raw lines -> 221 relevant turns, 19 user turns (was 0).
- `bun run typecheck` and `bun run build` pass.

__Note:__ source-only changes; `dist/` is gitignored. Run `bun run build` to regenerate.