### PR TITLE
Auto-start auth from Cursor session hook

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -5,6 +5,8 @@ import { randomBytes } from "node:crypto";
 
 const CREDENTIALS_DIR = path.join(os.homedir(), ".supermemory-cursor");
 const CREDENTIALS_FILE = path.join(CREDENTIALS_DIR, "credentials.json");
+const AUTH_ATTEMPTED_FILE = path.join(CREDENTIALS_DIR, ".auth-attempted");
+const LOGGED_OUT_FILE = path.join(CREDENTIALS_DIR, ".logged-out");
 const AUTH_URL = process.env.SUPERMEMORY_AUTH_URL || "https://app.supermemory.ai/auth/connect";
 const CURSOR_LOGO_FILE = path.join(import.meta.dir, "..", "assets", "cursor.png");
 
@@ -148,6 +150,8 @@ export function saveCredentials(apiKey: string): void {
   fs.mkdirSync(CREDENTIALS_DIR, { recursive: true, mode: 0o700 });
   const data = { apiKey, createdAt: new Date().toISOString() };
   fs.writeFileSync(CREDENTIALS_FILE, JSON.stringify(data, null, 2), { mode: 0o600 });
+  clearAuthAttempted();
+  clearLoggedOutMarker();
 }
 
 export function clearCredentials(): boolean {
@@ -160,6 +164,37 @@ export function clearCredentials(): boolean {
   } catch {
     return false;
   }
+}
+
+export function hasAuthAttempted(): boolean {
+  return fs.existsSync(AUTH_ATTEMPTED_FILE);
+}
+
+export function markAuthAttempted(): void {
+  fs.mkdirSync(CREDENTIALS_DIR, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(AUTH_ATTEMPTED_FILE, new Date().toISOString());
+}
+
+export function clearAuthAttempted(): void {
+  try {
+    if (fs.existsSync(AUTH_ATTEMPTED_FILE)) fs.unlinkSync(AUTH_ATTEMPTED_FILE);
+  } catch {}
+}
+
+export function isLoggedOut(): boolean {
+  return fs.existsSync(LOGGED_OUT_FILE);
+}
+
+export function markLoggedOut(): void {
+  fs.mkdirSync(CREDENTIALS_DIR, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(LOGGED_OUT_FILE, new Date().toISOString());
+  clearAuthAttempted();
+}
+
+export function clearLoggedOutMarker(): void {
+  try {
+    if (fs.existsSync(LOGGED_OUT_FILE)) fs.unlinkSync(LOGGED_OUT_FILE);
+  } catch {}
 }
 
 export async function startAuthFlow(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,9 @@ import {
   loadCredentials,
   startAuthFlow,
   clearCredentials,
+  clearAuthAttempted,
+  clearLoggedOutMarker,
+  markLoggedOut,
 } from "./auth.ts";
 
 const command = process.argv[2];
@@ -19,6 +22,8 @@ switch (command) {
       process.exit(0);
     }
     console.log("Opening browser to authenticate...");
+    clearAuthAttempted();
+    clearLoggedOutMarker();
     const result = await startAuthFlow();
     if (result.success) {
       console.log("Authenticated successfully.");
@@ -31,6 +36,7 @@ switch (command) {
 
   case "logout": {
     const removed = clearCredentials();
+    markLoggedOut();
     console.log(removed ? "Logged out." : "No credentials found.");
     break;
   }

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -1,4 +1,10 @@
-import { loadCredentials } from "../auth.ts";
+import {
+  clearAuthAttempted,
+  hasAuthAttempted,
+  isLoggedOut,
+  markAuthAttempted,
+  startAuthFlow,
+} from "../auth.ts";
 import { loadConfig, getApiKey } from "../config.ts";
 import { getUserTag, getProjectTag } from "../tags.ts";
 import { createClient } from "../client.ts";
@@ -16,11 +22,19 @@ async function main() {
   const raw = await Bun.stdin.text();
   const input: SessionStartInput = JSON.parse(raw);
 
-  const creds = loadCredentials();
-  if (!creds) return ok();
-
   const config = loadConfig(input.workspace_roots[0]);
-  const apiKey = getApiKey(config);
+  let apiKey = getApiKey(config);
+  if (!apiKey && !isLoggedOut() && !hasAuthAttempted()) {
+    try {
+      markAuthAttempted();
+      const authResult = await startAuthFlow();
+      if (authResult.success) {
+        clearAuthAttempted();
+        apiKey = getApiKey(config);
+      }
+    } catch {}
+  }
+
   if (!apiKey) return ok();
 
   // Inject user email from input for tag resolution


### PR DESCRIPTION
## Summary

- Start the browser auth flow from Cursor's `sessionStart` hook when no API key is configured.
- Add auth-attempted and logged-out markers so first-use auth does not nag after a failed/ignored prompt or explicit logout.
- Clear markers on successful/manual login so auth can be retried intentionally.

## Testing

- `bun run typecheck`
- `bun run build`
- Temporary-home smoke: pre-created `.supermemory-cursor/.auth-attempted`, ran `bun run src/hooks/session-start.ts`, confirmed it returned `{"continue":true}` without launching auth.

Stacked on #2 because the current Cursor auth branch contains the web-app OAuth routing this builds on.