### PR TITLE
Update Cursor install README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,15 @@ Persistent AI memory for Cursor — powered by [Supermemory](https://supermemory
 
 ## Install
 
-Install from the [Cursor Marketplace](https://cursor.com/marketplace), then authenticate:
+Install the Cursor integration with the Supermemory CLI:
+
+```bash
+npx supermemory plugin --only cursor
+```
+
+This installs the local Cursor plugin bundle and starts Supermemory auth. After it finishes, restart Cursor or run **Developer: Reload Window**.
+
+If you only need to authenticate an existing install, run:
 
 ```bash
 bunx cursor-supermemory@latest login
@@ -103,7 +111,7 @@ bun install
 bun run build   # compiles all dist/ files
 ```
 
-### Testing locally (without the marketplace)
+### Testing from this repo
 
 1. **Open this repo in Cursor** — rules, commands, skills, and hooks are picked up from `.cursor-plugin`.
 2. **Build:** `bun run build`

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Persistent AI memory for Cursor — powered by [Supermemory](https://supermemory
 
 ## Install
 
-Install the Cursor integration with the Supermemory CLI:
+Install the Cursor integration package:
 
 ```bash
-npx supermemory plugin --only cursor
+npm install cursor-supermemory@latest
 ```
 
-This installs the local Cursor plugin bundle and starts Supermemory auth. After it finishes, restart Cursor or run **Developer: Reload Window**.
+After it finishes, restart Cursor or run **Developer: Reload Window**.
 
 If you only need to authenticate an existing install, run:
 


### PR DESCRIPTION
## Summary
- Replace the Cursor Marketplace install instruction with the current `npx supermemory plugin --only cursor` flow.
- Keep `bunx cursor-supermemory@latest login` as the auth-only path for existing installs.
- Rename the local development section so it no longer references marketplace installation.