### PR TITLE
fix: add hooks config schema version

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "hooks": {
     "sessionStart": [
       {


### PR DESCRIPTION
## Summary

- Add the top-level `version: 1` field to `hooks/hooks.json`.
- Align the plugin hooks config with Cursor's documented hooks schema.

## Why

Without the schema version in the hooks config, Cursor did not load the plugin's `sessionStart`/`sessionEnd` hooks, while the plugin's rules, skills, and commands were recognized and loaded correctly. Adding `version: 1` fixed the hook loading.

Observed on Cursor 3.11.19.

Reference: https://cursor.com/docs/hooks#global-configuration-options

## Test plan

- `python3 -m json.tool hooks/hooks.json`
- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run build`