### PR TITLE
fix: scope MCP project memory to workspace root

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "supermemory": {
       "command": "bunx",
-      "args": [ "cursor-supermemory@latest", "mcp"]
+      "args": ["cursor-supermemory@latest", "mcp"],
+      "env": {
+        "SUPERMEMORY_WORKSPACE_ROOT": "${workspaceFolder}"
+      }
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "supermemory": {
       "command": "bunx",
-      "args": ["--bun", "cursor-supermemory@latest", "mcp"]
+      "args": ["--bun", "cursor-supermemory@latest", "mcp"],
+      "env": {
+        "SUPERMEMORY_WORKSPACE_ROOT": "${workspaceFolder}"
+      }
     }
   }
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -5,14 +5,23 @@ import { loadConfig, getApiKey, writeConfig, getProjectConfigPath, GLOBAL_CONFIG
 import { getUserTag, getProjectTag } from "./tags.ts";
 import { createClient } from "./client.ts";
 
+function getWorkspaceRoot() {
+  const workspaceRoot = process.env.SUPERMEMORY_WORKSPACE_ROOT?.trim();
+  if (workspaceRoot && !workspaceRoot.includes("${")) return workspaceRoot;
+  return process.cwd();
+}
+
 function getAuth() {
-  const config = loadConfig();
+  const workspaceRoot = getWorkspaceRoot();
+  const config = loadConfig(workspaceRoot);
   const apiKey = getApiKey(config);
   if (!apiKey) throw new Error("Not authenticated. Run `cursor-supermemory login` to connect.");
   return {
     apiKey,
     userTag: getUserTag(config),
-    projectTag: getProjectTag(process.cwd(), config),
+    projectTag: getProjectTag(workspaceRoot, config),
+    workspaceRoot,
+    config,
   };
 }
 
@@ -39,9 +48,8 @@ export async function startMcpServer() {
       inputSchema: {},
     },
     async () => {
-      const cwd = process.cwd();
-      const config = loadConfig(cwd);
       const auth = getAuth();
+      const { config, workspaceRoot } = auth;
       return {
         content: [
           {
@@ -61,7 +69,7 @@ export async function startMcpServer() {
                   project: auth.projectTag,
                 },
                 configFiles: {
-                  project: getProjectConfigPath(cwd),
+                  project: getProjectConfigPath(workspaceRoot),
                   global: GLOBAL_CONFIG_PATH,
                 },
               },
@@ -92,9 +100,9 @@ export async function startMcpServer() {
     async ({ scope, ...updates }) => {
       const filtered = Object.fromEntries(Object.entries(updates).filter(([, v]) => v !== undefined));
       if (Object.keys(filtered).length === 0) throw new Error("No config values provided.");
-      writeConfig(filtered as any, scope);
-      const cwd = process.cwd();
-      const filePath = scope === "project" ? getProjectConfigPath(cwd) : GLOBAL_CONFIG_PATH;
+      const workspaceRoot = getWorkspaceRoot();
+      writeConfig(filtered as any, scope, workspaceRoot);
+      const filePath = scope === "project" ? getProjectConfigPath(workspaceRoot) : GLOBAL_CONFIG_PATH;
       return {
         content: [{ type: "text", text: `Config updated (${scope}): ${filePath}\n${JSON.stringify(filtered, null, 2)}` }],
       };


### PR DESCRIPTION
## Summary

- Inject `${workspaceFolder}` into the MCP server as `SUPERMEMORY_WORKSPACE_ROOT`.
- Use the injected workspace root when resolving project config paths and project container tags.
- Keep `process.cwd()` as a fallback for non-Cursor or unresolved variable cases.

## Why

Cursor can spawn plugin/global MCP servers with `process.cwd()` set to the user's home directory instead of the active workspace. When the MCP server uses `process.cwd()` to derive the project container tag, different projects can write to the same project container.

I observed this with two separate git projects, `tessella` and `vibefolio`, where MCP-saved project memories were both stored in the same container:

- `cursor_project_76b5f714a5f645a1`

That tag is derived from `/home/iris`, not from either project's git root.

A temporary debug MCP server confirmed that:

- `process.cwd()` was `/home/iris` for multiple workspace windows.
- `${workspaceFolder}` resolved correctly per window:
  - `/home/iris/Workspace/tessella`
  - `/home/iris/Workspace/vibefolio`

Using `${workspaceFolder}` keeps MCP project memory scoped to the actual workspace, matching the session hooks' existing behavior of using `workspace_roots[0]`.

Reference: https://cursor.com/docs/mcp#config-interpolation

## Test plan

- `python3 -m json.tool .mcp.json`
- `python3 -m json.tool .cursor/mcp.json`
- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run build`
- Verified the built MCP server resolves distinct project tags when `SUPERMEMORY_WORKSPACE_ROOT` is set:
  - `/home/iris/Workspace/tessella` -> `cursor_project_0c98f8e4016b9d7b`
  - `/home/iris/Workspace/vibefolio` -> `cursor_project_6bcaea3f70809028`
- Verified the old fallback behavior remains when `SUPERMEMORY_WORKSPACE_ROOT` is not set:
  - cwd `/home/iris` -> `cursor_project_76b5f714a5f645a1`