### PR TITLE
feat: unify Cursor memory containers

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cursor-supermemory",
   "description": "Persistent AI memory for Cursor — powered by Supermemory",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "author": {
     "name": "Supermemory",
     "email": "dhravya@supermemory.com"

--- a/README.md
+++ b/README.md
@@ -38,9 +38,14 @@ bunx cursor-supermemory@latest login
 | `supermemory_profile` | Get your user profile summary |
 
 All tools that accept a `container` argument support:
-- `"user"` (default) — personal memory, shared across all projects
-- `"project"` — scoped to the current workspace
+- `"user"` (default) — personal memories for the current repository
+- `"project"` — project knowledge for the current repository
+- `"both"` — both scopes plus compatible legacy memories
 - any custom string — used as a raw container tag
+
+`user` and `project` now write to the same repository container. The
+`sm_scope` metadata field keeps personal/session memories separate from
+explicit project knowledge when an agent requests one scope.
 
 ## Configuration
 
@@ -49,9 +54,11 @@ All tools that accept a `container` argument support:
 | Variable | Description |
 |---|---|
 | `SUPERMEMORY_API_KEY` | API key (overrides all other sources) |
-| `SUPERMEMORY_USER_TAG` | Override the personal container tag |
-| `SUPERMEMORY_PROJECT_TAG` | Override the project container tag |
-| `CURSOR_USER_EMAIL` | Used to derive the user container tag |
+| `SUPERMEMORY_API_URL` | Override the Supermemory API base URL |
+| `SUPERMEMORY_REPO_TAG` | Override the unified repository container tag |
+| `SUPERMEMORY_USER_TAG` | Legacy Cursor personal container to continue reading |
+| `SUPERMEMORY_PROJECT_TAG` | Legacy Cursor project container to continue reading |
+| `CURSOR_USER_EMAIL` | Used only to find legacy Cursor personal memories |
 
 ### Global config — `~/.config/cursor/supermemory.json`
 
@@ -59,7 +66,7 @@ User-wide defaults, applies to all projects.
 
 ```json
 {
-  "userContainerTag": "my-personal-tag",
+  "repoContainerTag": "repo_my_project__0123456789abcdef",
   "similarityThreshold": 0.3,
   "maxMemories": 10,
   "maxProjectMemories": 5,
@@ -74,8 +81,7 @@ Per-workspace overrides. Add to `.gitignore` if it contains an API key. Project 
 ```json
 {
   "apiKey": "sm_...",
-  "projectContainerTag": "my-team-backend",
-  "userContainerTag": "my-personal-tag",
+  "repoContainerTag": "repo_my_project__0123456789abcdef",
   "similarityThreshold": 0.3,
   "maxMemories": 10,
   "maxProjectMemories": 5,
@@ -86,8 +92,10 @@ Per-workspace overrides. Add to `.gitignore` if it contains an API key. Project 
 | Option | Description | Default |
 |---|---|---|
 | `apiKey` | Project-specific API key | — |
-| `userContainerTag` | Override personal memory container | auto-derived from git email / machine id |
-| `projectContainerTag` | Override project memory container | auto-derived from git root / cwd |
+| `baseUrl` | Override the Supermemory API base URL | Supermemory API |
+| `repoContainerTag` | Override the unified repository container | derived from normalized Git remote or project path |
+| `userContainerTag` | Legacy Cursor personal container to continue reading | — |
+| `projectContainerTag` | Legacy Cursor project container to continue reading | — |
 | `similarityThreshold` | Minimum similarity score for search results | `0.3` |
 | `maxMemories` | Max project memories injected at session start | `10` |
 | `maxProjectMemories` | Max project memories injected at session start | `5` |
@@ -97,12 +105,21 @@ You can set these via the AI using `supermemory_set_config`, or create/edit the 
 
 ## Container tags
 
-By default, container tags are derived automatically:
+Cursor, Claude Code, Codex, and OpenCode use the same repository tag:
 
-- **User tag** — hashed from your git email, `CURSOR_USER_EMAIL`, or machine id. Consistent across projects.
-- **Project tag** — hashed from your git repo root (or cwd). Consistent across team members on the same repo.
+```text
+repo_<project_name>__<project_id>
+```
 
-To share project memory with your team, set the same `projectContainerTag` in everyone's project config.
+The project ID is a stable hash of the normalized Git remote. Repositories
+without a remote fall back to their resolved local path. This prevents two
+different repositories with the same directory name from colliding while
+letting different agents share memory for the same repository.
+
+The plugin continues reading the former Cursor `cursor_user_*` and
+`cursor_project_*` tags, along with legacy tags from the other supported
+agents. New writes only use the unified repository tag. Set
+`repoContainerTag` only when you need an explicit shared override.
 
 ## Development
 

--- a/commands/supermemory-config.md
+++ b/commands/supermemory-config.md
@@ -8,14 +8,17 @@ Create or edit `.cursor/.supermemory/config.json` at your project root:
 ```json
 {
   "apiKey": null,
-  "projectContainerTag": null,
-  "userContainerTag": null
+  "baseUrl": null,
+  "repoContainerTag": null
 }
 ```
 
 Settings:
 - `apiKey`: Override the global API key for this project
-- `projectContainerTag`: Custom tag for project memories (default: auto-generated from git root)
-- `userContainerTag`: Custom tag for user memories (default: auto-generated from email/machine)
+- `baseUrl`: Override the Supermemory API base URL
+- `repoContainerTag`: Override the unified repository tag (default: derived from the normalized Git remote or project path)
+
+The older `userContainerTag` and `projectContainerTag` options are retained
+only as compatibility read tags. New memories always use `repoContainerTag`.
 
 Add `.cursor/.supermemory/` to your `.gitignore` to keep credentials out of version control.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor-supermemory",
-  "version": "1.0.01",
+  "version": "1.0.2",
   "description": "Persistent AI memory for Cursor — powered by Supermemory",
   "type": "module",
   "bin": {
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "bun build ./src/cli.ts --outfile ./dist/cli.js --target node && bun build ./src/mcp-server.ts --outfile ./dist/mcp-server.js --target node && bun build ./src/hooks/session-start.ts --outfile ./dist/session-start.js --target node && bun build ./src/hooks/session-end.ts --outfile ./dist/session-end.js --target node",
     "typecheck": "tsc --noEmit",
+    "test": "bun test",
     "dev": "bun run src/cli.ts"
   },
   "dependencies": {

--- a/rules/supermemory.mdc
+++ b/rules/supermemory.mdc
@@ -11,6 +11,11 @@ You have access to Supermemory MCP tools for persistent memory across coding ses
 - `supermemory_list`: List recent memories for this project
 - `supermemory_forget`: Delete a specific memory by ID
 
+For every Supermemory tool call, pass `workspaceRoot` as the absolute path of
+the active Cursor workspace from the current agent context. Plugin MCP
+processes can be shared across windows, so the server process directory is not
+a reliable project identifier.
+
 When to use:
 - User mentions past sessions, previous work, or "last time" → search first
 - User says "remember", "save this", "don't forget" → add immediately

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,26 +1,405 @@
-import Supermemory from "supermemory";
 import { createHash, createHmac } from "node:crypto";
+import Supermemory from "supermemory";
 
 const INTEGRITY_VERSION = 1;
-const SEED = "7f2a9c4b8e1d6f3a5c0b9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a";
+const SEED =
+  "7f2a9c4b8e1d6f3a5c0b9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a";
+const CURSOR_SOURCE = "cursor";
 
-function sha256(input: string) {
+export type MemoryScope = "personal" | "project";
+
+export const AGENT_ENTITY_CONTEXT = `Shared coding-agent memory for one software repository.
+
+RULES:
+- Preserve durable context that helps Claude Code, Codex, OpenCode, or Cursor continue the work
+- Condense assistant responses into decisions, outcomes, and reusable knowledge
+- Keep user preferences and project facts concise and independently understandable
+
+EXTRACT:
+- User preferences, accepted decisions, durable workflows, actions, and learnings
+- Architecture, conventions, implementation patterns, setup requirements, and decisions
+
+SKIP:
+- Generic assistant suggestions the user did not accept
+- Transient command output and low-value implementation chatter
+- Granular details that do not help future work`;
+
+function sha256(input: string): string {
   return createHash("sha256").update(input).digest("hex");
 }
 
 function integrityHeaders(apiKey: string, containerTag: string) {
   const contentHash = sha256(containerTag);
   const payload = [sha256(apiKey), contentHash, INTEGRITY_VERSION].join(":");
-  const sig = createHmac("sha256", SEED).update(payload).digest("base64url");
+  const sig = createHmac("sha256", SEED)
+    .update(payload)
+    .digest("base64url");
   return {
     "X-Content-Hash": contentHash,
     "X-Request-Integrity": `v${INTEGRITY_VERSION}.${sig}`,
+    "x-sm-source": CURSOR_SOURCE,
   };
 }
 
-export function createClient(apiKey: string, containerTag = "cursor"): Supermemory {
+function scopeFilters(scope: MemoryScope) {
+  return {
+    AND: [{ key: "sm_scope", value: scope, filterType: "metadata" as const }],
+  };
+}
+
+function supportsScopedCanonicalTag(containerTag: string): boolean {
+  return /^repo_.+__[0-9a-f]{16}$/i.test(containerTag);
+}
+
+function unique<T>(values: T[], key: (value: T) => string): T[] {
+  const seen = new Set<string>();
+  return values.filter((value) => {
+    const normalized = key(value).trim().toLowerCase();
+    if (!normalized || seen.has(normalized)) return false;
+    seen.add(normalized);
+    return true;
+  });
+}
+
+function searchText(result: any): string {
+  return String(
+    result?.memory ??
+      result?.content ??
+      result?.chunk ??
+      result?.context ??
+      "",
+  );
+}
+
+function resultDate(result: any): number {
+  const value = result?.updatedAt ?? result?.createdAt;
+  const parsed = value ? new Date(value).getTime() : 0;
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function resultMetadata(result: any): Record<string, unknown> {
+  if (result?.metadata && typeof result.metadata === "object") {
+    return result.metadata as Record<string, unknown>;
+  }
+  if (
+    result?.document?.metadata &&
+    typeof result.document.metadata === "object"
+  ) {
+    return result.document.metadata as Record<string, unknown>;
+  }
+  return {};
+}
+
+function listItems(result: any): any[] {
+  if (Array.isArray(result?.memories)) return result.memories;
+  if (Array.isArray(result?.documents)) return result.documents;
+  if (Array.isArray(result?.items)) return result.items;
+  return [];
+}
+
+function profileFacts(result: any, kind: "static" | "dynamic"): string[] {
+  const facts = result?.profile?.[kind];
+  return Array.isArray(facts)
+    ? facts.filter((fact): fact is string => typeof fact === "string")
+    : [];
+}
+
+function searchResults(result: any): any[] {
+  const values = result?.searchResults?.results ?? result?.results;
+  return Array.isArray(values) ? values : [];
+}
+
+export function mergeSearchResults(
+  responses: any[],
+  limit: number,
+): { results: any[]; total: number } {
+  const merged = responses.flatMap((response) =>
+    searchResults(response).map((result) => ({
+      ...result,
+      memory: searchText(result),
+    })),
+  );
+  const results = unique(merged, (result) => result.id || searchText(result))
+    .sort(
+      (a, b) =>
+        Number(b.similarity ?? b.score ?? 0) -
+          Number(a.similarity ?? a.score ?? 0) ||
+        resultDate(b) - resultDate(a),
+    )
+    .slice(0, limit);
+  return { results, total: results.length };
+}
+
+function mergeProfiles(responses: any[], limit: number) {
+  const staticFacts = unique(
+    responses.flatMap((result) => profileFacts(result, "static")),
+    (fact) => fact,
+  );
+  const dynamicFacts = unique(
+    responses.flatMap((result) => profileFacts(result, "dynamic")),
+    (fact) => fact,
+  ).filter(
+    (fact) =>
+      !new Set(staticFacts.map((value) => value.toLowerCase())).has(
+        fact.toLowerCase(),
+      ),
+  );
+  const mergedSearch = mergeSearchResults(responses, limit);
+  return {
+    profile: { static: staticFacts, dynamic: dynamicFacts },
+    searchResults: mergedSearch,
+  };
+}
+
+function mergeLists(responses: any[], limit: number) {
+  const memories = unique(
+    responses.flatMap(listItems),
+    (item) => String(item?.id ?? searchText(item)),
+  )
+    .sort((a, b) => resultDate(b) - resultDate(a))
+    .slice(0, limit);
+  return { memories };
+}
+
+function fulfilledOrThrow<T>(
+  settled: PromiseSettledResult<T>[],
+  message: string,
+): T[] {
+  const successful = settled
+    .filter(
+      (result): result is PromiseFulfilledResult<T> =>
+        result.status === "fulfilled",
+    )
+    .map((result) => result.value);
+  if (successful.length > 0) return successful;
+  const firstError = settled.find(
+    (result): result is PromiseRejectedResult =>
+      result.status === "rejected",
+  );
+  throw firstError?.reason ?? new Error(message);
+}
+
+export class CursorMemoryClient {
+  constructor(
+    private readonly apiKey: string,
+    private readonly baseUrl?: string | null,
+  ) {}
+
+  private raw(containerTag: string): Supermemory {
+    return new Supermemory({
+      apiKey: this.apiKey,
+      baseURL: this.baseUrl || undefined,
+      defaultHeaders: integrityHeaders(this.apiKey, containerTag),
+    });
+  }
+
+  async addMemory(
+    content: string,
+    containerTag: string,
+    metadata: Record<string, unknown>,
+    options: { customId?: string; entityContext?: string } = {},
+  ) {
+    return this.raw(containerTag).add({
+      content,
+      containerTag,
+      metadata: { sm_source: CURSOR_SOURCE, ...metadata },
+      customId: options.customId,
+      entityContext: options.entityContext,
+    });
+  }
+
+  private async searchOne(
+    query: string,
+    containerTag: string,
+    limit: number,
+    scope?: MemoryScope,
+  ) {
+    const result = await this.raw(containerTag).search.memories({
+      q: query,
+      containerTag,
+      limit,
+      searchMode: "hybrid",
+      filters: scope ? scopeFilters(scope) : undefined,
+    });
+    return {
+      ...result,
+      results: (result.results ?? []).map((item: any) => ({
+        ...item,
+        memory: searchText(item),
+        containerTag,
+      })),
+    };
+  }
+
+  async searchMany(query: string, containerTags: string[], limit: number) {
+    const settled = await Promise.allSettled(
+      [...new Set(containerTags.filter(Boolean))].map((containerTag) =>
+        this.searchOne(query, containerTag, limit),
+      ),
+    );
+    return mergeSearchResults(
+      fulfilledOrThrow(settled, "No memory containers could be searched"),
+      limit,
+    );
+  }
+
+  async searchScoped(
+    query: string,
+    canonicalTag: string,
+    containerTags: string[],
+    scope: MemoryScope,
+    limit: number,
+  ) {
+    const legacyTags = [
+      ...new Set(
+        containerTags.filter(
+          (tag) => tag && tag !== canonicalTag,
+        ),
+      ),
+    ];
+    const settled = await Promise.allSettled([
+      this.searchOne(
+        query,
+        canonicalTag,
+        limit,
+        supportsScopedCanonicalTag(canonicalTag) ? scope : undefined,
+      ),
+      ...legacyTags.map((tag) => this.searchOne(query, tag, limit)),
+    ]);
+    return mergeSearchResults(
+      fulfilledOrThrow(settled, "No memory containers could be searched"),
+      limit,
+    );
+  }
+
+  private async profileOne(
+    containerTag: string,
+    query?: string,
+    scope?: MemoryScope,
+  ) {
+    return this.raw(containerTag).profile({
+      containerTag,
+      q: query,
+      filters: scope ? scopeFilters(scope) : undefined,
+    } as any);
+  }
+
+  async profileScoped(
+    canonicalTag: string,
+    containerTags: string[],
+    scope: MemoryScope,
+    query: string | undefined,
+    limit: number,
+  ) {
+    const legacyTags = [
+      ...new Set(
+        containerTags.filter(
+          (tag) => tag && tag !== canonicalTag,
+        ),
+      ),
+    ];
+    const settled = await Promise.allSettled([
+      this.profileOne(
+        canonicalTag,
+        query,
+        supportsScopedCanonicalTag(canonicalTag) ? scope : undefined,
+      ),
+      ...legacyTags.map((tag) => this.profileOne(tag, query)),
+    ]);
+    return mergeProfiles(
+      fulfilledOrThrow(settled, "No memory profiles could be loaded"),
+      limit,
+    );
+  }
+
+  private async listOne(
+    containerTag: string,
+    limit: number,
+    page: number,
+    scope?: MemoryScope,
+  ) {
+    const result = await this.raw(containerTag).documents.list({
+      containerTags: [containerTag],
+      limit,
+      page,
+    });
+    if (!scope) return result;
+    const memories = listItems(result).filter(
+      (item) => resultMetadata(item).sm_scope === scope,
+    );
+    return { ...result, memories };
+  }
+
+  async listScoped(
+    canonicalTag: string,
+    containerTags: string[],
+    scope: MemoryScope,
+    limit: number,
+    page = 1,
+  ) {
+    const legacyTags = [
+      ...new Set(
+        containerTags.filter(
+          (tag) => tag && tag !== canonicalTag,
+        ),
+      ),
+    ];
+    const settled = await Promise.allSettled([
+      this.listOne(
+        canonicalTag,
+        Math.max(limit * 10, 100),
+        page,
+        supportsScopedCanonicalTag(canonicalTag) ? scope : undefined,
+      ),
+      ...legacyTags.map((tag) => this.listOne(tag, limit, page)),
+    ]);
+    return mergeLists(
+      fulfilledOrThrow(settled, "No memory containers could be listed"),
+      limit,
+    );
+  }
+
+  async listMany(containerTags: string[], limit: number, page = 1) {
+    const settled = await Promise.allSettled(
+      [...new Set(containerTags.filter(Boolean))].map((tag) =>
+        this.listOne(tag, limit, page),
+      ),
+    );
+    return mergeLists(
+      fulfilledOrThrow(settled, "No memory containers could be listed"),
+      limit,
+    );
+  }
+
+  async forgetMany(
+    containerTags: string[],
+    input: { id?: string; content?: string },
+  ) {
+    const settled = await Promise.allSettled(
+      [...new Set(containerTags.filter(Boolean))].map((containerTag) =>
+        this.raw(containerTag).memories.forget({
+          containerTag,
+          ...input,
+        }),
+      ),
+    );
+    const successful = fulfilledOrThrow(
+      settled,
+      "No memory containers could be updated",
+    );
+    return { forgottenFrom: successful.length, results: successful };
+  }
+}
+
+/** Raw SDK compatibility helper retained for external imports. */
+export function createClient(
+  apiKey: string,
+  containerTag = "cursor",
+  baseUrl?: string | null,
+): Supermemory {
   return new Supermemory({
     apiKey,
+    baseURL: baseUrl || undefined,
     defaultHeaders: integrityHeaders(apiKey, containerTag),
   });
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,19 +18,23 @@ export function writeConfig(updates: Partial<Omit<Config, "apiKey">>, scope: "pr
 
 export interface Config {
   apiKey: string | null;
+  baseUrl: string | null;
   similarityThreshold: number;
   maxMemories: number;
   maxProjectMemories: number;
   injectProfile: boolean;
+  repoContainerTag: string | null;
   userContainerTag: string | null;
   projectContainerTag: string | null;
 }
 
 const DEFAULTS: Omit<Config, "apiKey"> = {
+  baseUrl: null,
   similarityThreshold: 0.3,
   maxMemories: 10,
   maxProjectMemories: 5,
   injectProfile: true,
+  repoContainerTag: null,
   userContainerTag: null,
   projectContainerTag: null,
 };
@@ -66,10 +70,16 @@ export function loadConfig(cwd?: string): Config {
 
   return {
     apiKey: process.env.SUPERMEMORY_API_KEY ?? merged.apiKey ?? null,
+    baseUrl:
+      process.env.SUPERMEMORY_API_URL ??
+      process.env.SUPERMEMORY_BASE_URL ??
+      merged.baseUrl ??
+      null,
     similarityThreshold: merged.similarityThreshold,
     maxMemories: merged.maxMemories,
     maxProjectMemories: merged.maxProjectMemories,
     injectProfile: merged.injectProfile,
+    repoContainerTag: merged.repoContainerTag,
     userContainerTag: merged.userContainerTag,
     projectContainerTag: merged.projectContainerTag,
   };

--- a/src/context.ts
+++ b/src/context.ts
@@ -13,8 +13,15 @@ function formatRelativeTime(dateStr: string): string {
   return `${Math.floor(weeks)}w ago`;
 }
 
-export function formatContext(profile: any, memories: any[]): string {
-  const profileItems: string[] = profile?.static ?? profile?.dynamic ?? [];
+export function formatContext(
+  profile: any,
+  memories: any[],
+  maxLength = MAX_LENGTH,
+): string {
+  const profileItems: string[] = [
+    ...(Array.isArray(profile?.static) ? profile.static : []),
+    ...(Array.isArray(profile?.dynamic) ? profile.dynamic : []),
+  ];
   const hasProfile = profileItems.length > 0;
   const hasMemories = memories?.length > 0;
 
@@ -44,8 +51,8 @@ export function formatContext(profile: any, memories: any[]): string {
   sections.push("\nUse these memories when relevant. Don't force them into every response.");
 
   let result = sections.join("\n");
-  if (result.length > MAX_LENGTH) {
-    result = result.slice(0, MAX_LENGTH - 3) + "...";
+  if (result.length > maxLength) {
+    result = result.slice(0, maxLength - 3) + "...";
   }
   return result;
 }

--- a/src/hooks/session-end.ts
+++ b/src/hooks/session-end.ts
@@ -1,7 +1,10 @@
-import { loadCredentials } from "../auth.ts";
+import { createHash } from "node:crypto";
 import { loadConfig, getApiKey } from "../config.ts";
-import { getUserTag, getProjectTag } from "../tags.ts";
-import { createClient } from "../client.ts";
+import { getResolvedTags } from "../tags.ts";
+import {
+  AGENT_ENTITY_CONTEXT,
+  CursorMemoryClient,
+} from "../client.ts";
 
 interface SessionEndInput {
   session_id: string;
@@ -52,6 +55,11 @@ function parseTranscript(text: string): Turn[] {
     .filter(Boolean);
 }
 
+function captureId(sessionId: string): string {
+  const digest = createHash("sha256").update(sessionId).digest("hex");
+  return `cursor:capture:${digest}`;
+}
+
 async function main() {
   const raw = await Bun.stdin.text();
   const input: SessionEndInput = JSON.parse(raw);
@@ -62,9 +70,6 @@ async function main() {
   // ended abnormally ("aborted"/"error").
   const NON_PERSISTABLE_REASONS = new Set(["aborted", "error"]);
   if (!input.transcript_path || NON_PERSISTABLE_REASONS.has(input.reason ?? "")) return;
-
-  const creds = loadCredentials();
-  if (!creds) return;
 
   // Cursor spawns this hook from ~/.cursor, so process.cwd() is NOT the
   // workspace. Resolve config + project tag from workspace_roots[0] (as
@@ -85,20 +90,36 @@ async function main() {
   if (userTurns.length < 2) return;
 
   let transcript = relevant
-    .map((t) => `${t.role === "user" ? "User" : "Assistant"}: ${t.text}`)
+    .map(
+      (turn, index) =>
+        `${index + 1}. [${turn.role}] ${turn.text}`,
+    )
     .join("\n");
   if (transcript.length > 100_000) {
     transcript = transcript.slice(0, 100_000);
   }
 
-  const userTag = getUserTag(config);
-  const projectTag = getProjectTag(workspaceRoot, config);
-  const content = `Cursor IDE session transcript:\n${transcript}`;
+  const tags = getResolvedTags(workspaceRoot, config);
+  const content = `[Conversation ${input.session_id}]\n${transcript}`;
+  const client = new CursorMemoryClient(apiKey, config.baseUrl);
 
-  await Promise.allSettled([
-    createClient(apiKey, userTag).add({ content, containerTag: userTag }),
-    createClient(apiKey, projectTag).add({ content, containerTag: projectTag }),
-  ]);
+  await client.addMemory(
+    content,
+    tags.canonical,
+    {
+      type: "conversation",
+      project: tags.projectName,
+      sm_project_id: tags.projectId,
+      sm_scope: "personal",
+      sm_capture_mode: "session_end",
+      sessionId: input.session_id,
+      timestamp: new Date().toISOString(),
+    },
+    {
+      customId: captureId(input.session_id),
+      entityContext: AGENT_ENTITY_CONTEXT,
+    },
+  );
 }
 
 main().catch((err) => {

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -1,7 +1,6 @@
-import { loadCredentials } from "../auth.ts";
 import { loadConfig, getApiKey } from "../config.ts";
-import { getUserTag, getProjectTag } from "../tags.ts";
-import { createClient } from "../client.ts";
+import { getResolvedTags } from "../tags.ts";
+import { CursorMemoryClient } from "../client.ts";
 import { formatContext } from "../context.ts";
 
 interface SessionStartInput {
@@ -16,10 +15,8 @@ async function main() {
   const raw = await Bun.stdin.text();
   const input: SessionStartInput = JSON.parse(raw);
 
-  const creds = loadCredentials();
-  if (!creds) return ok();
-
-  const config = loadConfig(input.workspace_roots[0]);
+  const workspaceRoot = input.workspace_roots?.[0] || process.cwd();
+  const config = loadConfig(workspaceRoot);
   const apiKey = getApiKey(config);
   if (!apiKey) return ok();
 
@@ -28,17 +25,31 @@ async function main() {
     process.env.CURSOR_USER_EMAIL = input.user_email;
   }
 
-  const userTag = getUserTag(config);
-  const projectTag = getProjectTag(input.workspace_roots[0] || process.cwd(), config);
+  const tags = getResolvedTags(workspaceRoot, config);
+  const client = new CursorMemoryClient(apiKey, config.baseUrl);
 
-  // Use documents.list (recency-ordered) rather than search.memories: the v4
-  // search endpoint rejects the empty query we'd need to "list everything".
   const [profileResult, memoriesResult] = await Promise.allSettled([
-    createClient(apiKey, userTag).profile({ containerTag: userTag }),
-    createClient(apiKey, projectTag).documents.list({ containerTags: [projectTag], limit: 10 }),
+    config.injectProfile
+      ? client.profileScoped(
+          tags.canonical,
+          tags.personalReads,
+          "personal",
+          undefined,
+          config.maxMemories,
+        )
+      : Promise.resolve(null),
+    client.listScoped(
+      tags.canonical,
+      tags.projectReads,
+      "project",
+      config.maxProjectMemories,
+    ),
   ]);
 
-  const profile = profileResult.status === "fulfilled" ? profileResult.value.profile : null;
+  const profile =
+    profileResult.status === "fulfilled" && profileResult.value
+      ? profileResult.value.profile
+      : null;
   const memories =
     memoriesResult.status === "fulfilled" ? (memoriesResult.value.memories ?? []) : [];
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,5 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { realpathSync, statSync } from "node:fs";
+import { isAbsolute } from "node:path";
 import { z } from "zod";
 import {
   GLOBAL_CONFIG_PATH,
@@ -30,6 +32,26 @@ function getAuth(cwd = process.cwd()) {
     tags,
     client: new CursorMemoryClient(apiKey, config.baseUrl),
   };
+}
+
+export function resolveWorkspaceRoot(workspaceRoot: string): string {
+  const candidate = workspaceRoot.trim();
+  if (!isAbsolute(candidate)) {
+    throw new Error("workspaceRoot must be an absolute path.");
+  }
+
+  try {
+    const resolved = realpathSync(candidate);
+    if (!statSync(resolved).isDirectory()) {
+      throw new Error("workspaceRoot must point to a directory.");
+    }
+    return resolved;
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("workspaceRoot")) {
+      throw error;
+    }
+    throw new Error(`workspaceRoot is not an accessible directory: ${candidate}`);
+  }
 }
 
 interface ResolvedContainer {
@@ -77,19 +99,32 @@ const containerSchema = z
     'Container to use: "user" (default), "project", "both", or any custom tag string',
   );
 
-export async function startMcpServer() {
-  const server = new McpServer({ name: "supermemory", version: "1.0.2" });
+const workspaceRootSchema = z
+  .string()
+  .min(1)
+  .describe(
+    "Absolute path of the active Cursor workspace. Always pass the workspace root shown in the current agent context.",
+  );
+
+export function createMcpServer() {
+  const server = new McpServer(
+    { name: "supermemory", version: "1.0.2" },
+    {
+      instructions:
+        "Every tool call requires workspaceRoot. Pass the absolute path of the active Cursor workspace from the current agent context.",
+    },
+  );
 
   server.registerTool(
     "supermemory_get_config",
     {
       description:
         "Show the current supermemory configuration — effective settings, resolved container tags, and config file paths.",
-      inputSchema: {},
+      inputSchema: { workspaceRoot: workspaceRootSchema },
     },
-    async () => {
-      const cwd = process.cwd();
-      const auth = getAuth();
+    async ({ workspaceRoot }) => {
+      const cwd = resolveWorkspaceRoot(workspaceRoot);
+      const auth = getAuth(cwd);
       return {
         content: [
           {
@@ -150,6 +185,7 @@ export async function startMcpServer() {
       description:
         "Update supermemory configuration. Use scope='project' to set per-workspace overrides (saved to .cursor/.supermemory/config.json), or scope='global' for user-wide defaults.",
       inputSchema: {
+        workspaceRoot: workspaceRootSchema,
         scope: z.enum(["project", "global"]).default("project"),
         repoContainerTag: z
           .string()
@@ -170,15 +206,15 @@ export async function startMcpServer() {
         injectProfile: z.boolean().optional(),
       },
     },
-    async ({ scope, ...updates }) => {
+    async ({ workspaceRoot, scope, ...updates }) => {
       const filtered = Object.fromEntries(
         Object.entries(updates).filter(([, value]) => value !== undefined),
       );
       if (Object.keys(filtered).length === 0) {
         throw new Error("No config values provided.");
       }
-      writeConfig(filtered as any, scope);
-      const cwd = process.cwd();
+      const cwd = resolveWorkspaceRoot(workspaceRoot);
+      writeConfig(filtered as any, scope, cwd);
       const filePath =
         scope === "project" ? getProjectConfigPath(cwd) : GLOBAL_CONFIG_PATH;
       return {
@@ -198,10 +234,10 @@ export async function startMcpServer() {
       description:
         "Show the shared repository container and all compatibility read tags. " +
         '"user" and "project" write to the same container with different sm_scope metadata.',
-      inputSchema: {},
+      inputSchema: { workspaceRoot: workspaceRootSchema },
     },
-    async () => {
-      const auth = getAuth();
+    async ({ workspaceRoot }) => {
+      const auth = getAuth(resolveWorkspaceRoot(workspaceRoot));
       return {
         content: [
           {
@@ -245,10 +281,15 @@ export async function startMcpServer() {
     {
       description:
         'Search memories. Use container="user" for personal, "project" for workspace, or pass a custom tag.',
-      inputSchema: { query: z.string(), container: containerSchema, limit: z.number().default(10) },
+      inputSchema: {
+        workspaceRoot: workspaceRootSchema,
+        query: z.string(),
+        container: containerSchema,
+        limit: z.number().default(10),
+      },
     },
-    async ({ query, container, limit }) => {
-      const auth = getAuth();
+    async ({ workspaceRoot, query, container, limit }) => {
+      const auth = getAuth(resolveWorkspaceRoot(workspaceRoot));
       const resolved = resolveContainer(auth.tags, container);
       const result = resolved.scope
         ? await auth.client.searchScoped(
@@ -275,15 +316,19 @@ export async function startMcpServer() {
     {
       description:
         'Save information to memory. Use container="user" for personal, "project" for workspace, or a custom tag.',
-      inputSchema: { content: z.string(), container: containerSchema },
+      inputSchema: {
+        workspaceRoot: workspaceRootSchema,
+        content: z.string(),
+        container: containerSchema,
+      },
     },
-    async ({ content, container }) => {
+    async ({ workspaceRoot, content, container }) => {
       if (container === "both") {
         throw new Error(
           'The "both" alias is read-only. Choose "user" or "project" when saving.',
         );
       }
-      const auth = getAuth();
+      const auth = getAuth(resolveWorkspaceRoot(workspaceRoot));
       const resolved = resolveContainer(auth.tags, container);
       const result = await auth.client.addMemory(
         content,
@@ -306,10 +351,13 @@ export async function startMcpServer() {
     "supermemory_profile",
     {
       description: "Get the user's profile summary based on their personal memories.",
-      inputSchema: { query: z.string().optional() },
+      inputSchema: {
+        workspaceRoot: workspaceRootSchema,
+        query: z.string().optional(),
+      },
     },
-    async ({ query }) => {
-      const auth = getAuth();
+    async ({ workspaceRoot, query }) => {
+      const auth = getAuth(resolveWorkspaceRoot(workspaceRoot));
       const result = await auth.client.profileScoped(
         auth.tags.canonical,
         auth.tags.personalReads,
@@ -325,10 +373,15 @@ export async function startMcpServer() {
     "supermemory_list",
     {
       description: "List stored memories, optionally filtered by container.",
-      inputSchema: { limit: z.number().default(20), page: z.number().default(1), container: containerSchema },
+      inputSchema: {
+        workspaceRoot: workspaceRootSchema,
+        limit: z.number().default(20),
+        page: z.number().default(1),
+        container: containerSchema,
+      },
     },
-    async ({ limit, page, container }) => {
-      const auth = getAuth();
+    async ({ workspaceRoot, limit, page, container }) => {
+      const auth = getAuth(resolveWorkspaceRoot(workspaceRoot));
       const resolved = resolveContainer(auth.tags, container);
       const result = resolved.scope
         ? await auth.client.listScoped(
@@ -348,14 +401,15 @@ export async function startMcpServer() {
     {
       description: "Forget a specific memory by id or content.",
       inputSchema: {
+        workspaceRoot: workspaceRootSchema,
         id: z.string().optional(),
         content: z.string().optional(),
         container: containerSchema,
       },
     },
-    async ({ id, content, container }) => {
+    async ({ workspaceRoot, id, content, container }) => {
       if (!id && !content) throw new Error("Provide either id or content.");
-      const auth = getAuth();
+      const auth = getAuth(resolveWorkspaceRoot(workspaceRoot));
       const resolved = resolveContainer(auth.tags, container);
       const result = await auth.client.forgetMany(resolved.reads, {
         id,
@@ -365,5 +419,10 @@ export async function startMcpServer() {
     },
   );
 
+  return server;
+}
+
+export async function startMcpServer() {
+  const server = createMcpServer();
   await server.connect(new StdioServerTransport());
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,35 +1,84 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { loadConfig, getApiKey, writeConfig, getProjectConfigPath, GLOBAL_CONFIG_PATH } from "./config.ts";
-import { getUserTag, getProjectTag } from "./tags.ts";
-import { createClient } from "./client.ts";
+import {
+  GLOBAL_CONFIG_PATH,
+  getApiKey,
+  getProjectConfigPath,
+  loadConfig,
+  writeConfig,
+} from "./config.ts";
+import { getResolvedTags, type ResolvedTags } from "./tags.ts";
+import {
+  AGENT_ENTITY_CONTEXT,
+  CursorMemoryClient,
+  type MemoryScope,
+} from "./client.ts";
 
-function getAuth() {
-  const config = loadConfig();
+function getAuth(cwd = process.cwd()) {
+  const config = loadConfig(cwd);
   const apiKey = getApiKey(config);
-  if (!apiKey) throw new Error("Not authenticated. Run `cursor-supermemory login` to connect.");
+  if (!apiKey) {
+    throw new Error(
+      "Not authenticated. Run `cursor-supermemory login` to connect.",
+    );
+  }
+  const tags = getResolvedTags(cwd, config);
   return {
     apiKey,
-    userTag: getUserTag(config),
-    projectTag: getProjectTag(process.cwd(), config),
+    config,
+    tags,
+    client: new CursorMemoryClient(apiKey, config.baseUrl),
   };
 }
 
-// "user" → personal tag, "project" → project tag, anything else → used as-is
-function resolveContainer(auth: { userTag: string; projectTag: string }, container?: string): string {
-  if (!container || container === "user") return auth.userTag;
-  if (container === "project") return auth.projectTag;
-  return container;
+interface ResolvedContainer {
+  tag: string;
+  reads: string[];
+  scope: MemoryScope | null;
+  custom: boolean;
+}
+
+function resolveContainer(
+  tags: ResolvedTags,
+  container?: string,
+): ResolvedContainer {
+  if (!container || container === "user") {
+    return {
+      tag: tags.canonical,
+      reads: tags.personalReads,
+      scope: "personal",
+      custom: false,
+    };
+  }
+  if (container === "project") {
+    return {
+      tag: tags.canonical,
+      reads: tags.projectReads,
+      scope: "project",
+      custom: false,
+    };
+  }
+  if (container === "both") {
+    return {
+      tag: tags.canonical,
+      reads: tags.allReads,
+      scope: null,
+      custom: false,
+    };
+  }
+  return { tag: container, reads: [container], scope: null, custom: true };
 }
 
 const containerSchema = z
   .string()
   .optional()
-  .describe('Container to use: "user" (default), "project" (current project), or any custom tag string');
+  .describe(
+    'Container to use: "user" (default), "project", "both", or any custom tag string',
+  );
 
 export async function startMcpServer() {
-  const server = new McpServer({ name: "supermemory", version: "1.0.0" });
+  const server = new McpServer({ name: "supermemory", version: "1.0.2" });
 
   server.registerTool(
     "supermemory_get_config",
@@ -40,7 +89,6 @@ export async function startMcpServer() {
     },
     async () => {
       const cwd = process.cwd();
-      const config = loadConfig(cwd);
       const auth = getAuth();
       return {
         content: [
@@ -49,16 +97,38 @@ export async function startMcpServer() {
             text: JSON.stringify(
               {
                 effectiveConfig: {
-                  userContainerTag: config.userContainerTag ?? "(auto-derived from git email / machine id)",
-                  projectContainerTag: config.projectContainerTag ?? "(auto-derived from git root / cwd)",
-                  similarityThreshold: config.similarityThreshold,
-                  maxMemories: config.maxMemories,
-                  maxProjectMemories: config.maxProjectMemories,
-                  injectProfile: config.injectProfile,
+                  repoContainerTag:
+                    auth.config.repoContainerTag ??
+                    "(derived from the normalized Git remote or project path)",
+                  similarityThreshold: auth.config.similarityThreshold,
+                  maxMemories: auth.config.maxMemories,
+                  maxProjectMemories: auth.config.maxProjectMemories,
+                  injectProfile: auth.config.injectProfile,
+                  baseUrl: auth.config.baseUrl ?? "(default API)",
                 },
-                resolvedTags: {
-                  user: auth.userTag,
-                  project: auth.projectTag,
+                project: {
+                  name: auth.tags.projectName,
+                  id: auth.tags.projectId,
+                  canonicalContainer: auth.tags.canonical,
+                },
+                writes: {
+                  user: {
+                    tag: auth.tags.canonical,
+                    sm_scope: "personal",
+                  },
+                  project: {
+                    tag: auth.tags.canonical,
+                    sm_scope: "project",
+                  },
+                },
+                reads: {
+                  user: auth.tags.personalReads,
+                  project: auth.tags.projectReads,
+                  both: auth.tags.allReads,
+                },
+                legacyCursorOverrides: {
+                  userContainerTag: auth.config.userContainerTag,
+                  projectContainerTag: auth.config.projectContainerTag,
                 },
                 configFiles: {
                   project: getProjectConfigPath(cwd),
@@ -81,8 +151,19 @@ export async function startMcpServer() {
         "Update supermemory configuration. Use scope='project' to set per-workspace overrides (saved to .cursor/.supermemory/config.json), or scope='global' for user-wide defaults.",
       inputSchema: {
         scope: z.enum(["project", "global"]).default("project"),
-        userContainerTag: z.string().optional().describe("Override the personal memory container tag"),
-        projectContainerTag: z.string().optional().describe("Override the project/workspace memory container tag"),
+        repoContainerTag: z
+          .string()
+          .optional()
+          .describe("Override the shared repository memory container tag"),
+        userContainerTag: z
+          .string()
+          .optional()
+          .describe("Legacy Cursor personal container to keep reading"),
+        projectContainerTag: z
+          .string()
+          .optional()
+          .describe("Legacy Cursor project container to keep reading"),
+        baseUrl: z.string().url().optional(),
         similarityThreshold: z.number().min(0).max(1).optional(),
         maxMemories: z.number().int().positive().optional(),
         maxProjectMemories: z.number().int().positive().optional(),
@@ -90,13 +171,23 @@ export async function startMcpServer() {
       },
     },
     async ({ scope, ...updates }) => {
-      const filtered = Object.fromEntries(Object.entries(updates).filter(([, v]) => v !== undefined));
-      if (Object.keys(filtered).length === 0) throw new Error("No config values provided.");
+      const filtered = Object.fromEntries(
+        Object.entries(updates).filter(([, value]) => value !== undefined),
+      );
+      if (Object.keys(filtered).length === 0) {
+        throw new Error("No config values provided.");
+      }
       writeConfig(filtered as any, scope);
       const cwd = process.cwd();
-      const filePath = scope === "project" ? getProjectConfigPath(cwd) : GLOBAL_CONFIG_PATH;
+      const filePath =
+        scope === "project" ? getProjectConfigPath(cwd) : GLOBAL_CONFIG_PATH;
       return {
-        content: [{ type: "text", text: `Config updated (${scope}): ${filePath}\n${JSON.stringify(filtered, null, 2)}` }],
+        content: [
+          {
+            type: "text",
+            text: `Config updated (${scope}): ${filePath}\n${JSON.stringify(filtered, null, 2)}`,
+          },
+        ],
       };
     },
   );
@@ -105,8 +196,8 @@ export async function startMcpServer() {
     "supermemory_containers",
     {
       description:
-        "Show the available container tags. Use these as the `container` argument in other tools. " +
-        '"user" is personal memory, "project" is scoped to the current workspace.',
+        "Show the shared repository container and all compatibility read tags. " +
+        '"user" and "project" write to the same container with different sm_scope metadata.',
       inputSchema: {},
     },
     async () => {
@@ -117,8 +208,28 @@ export async function startMcpServer() {
             type: "text",
             text: JSON.stringify(
               {
-                user: { alias: "user", tag: auth.userTag, description: "Personal memories across all projects" },
-                project: { alias: "project", tag: auth.projectTag, description: "Memories scoped to this workspace" },
+                repository: {
+                  name: auth.tags.projectName,
+                  id: auth.tags.projectId,
+                  tag: auth.tags.canonical,
+                },
+                user: {
+                  alias: "user",
+                  tag: auth.tags.canonical,
+                  sm_scope: "personal",
+                  reads: auth.tags.personalReads,
+                },
+                project: {
+                  alias: "project",
+                  tag: auth.tags.canonical,
+                  sm_scope: "project",
+                  reads: auth.tags.projectReads,
+                },
+                both: {
+                  alias: "both",
+                  tag: auth.tags.canonical,
+                  reads: auth.tags.allReads,
+                },
               },
               null,
               2,
@@ -138,14 +249,22 @@ export async function startMcpServer() {
     },
     async ({ query, container, limit }) => {
       const auth = getAuth();
-      const tag = resolveContainer(auth, container);
-      const client = createClient(auth.apiKey, tag);
-      const result = await client.search.memories({ q: query, containerTag: tag, limit });
-      const formatted = result.results.map((r) => ({
-        id: r.id,
-        memory: r.memory ?? r.chunk ?? "",
-        similarity: r.similarity,
-        updatedAt: r.updatedAt,
+      const resolved = resolveContainer(auth.tags, container);
+      const result = resolved.scope
+        ? await auth.client.searchScoped(
+            query,
+            resolved.tag,
+            resolved.reads,
+            resolved.scope,
+            limit,
+          )
+        : await auth.client.searchMany(query, resolved.reads, limit);
+      const formatted = result.results.map((result: any) => ({
+        id: result.id,
+        memory: result.memory ?? result.chunk ?? "",
+        similarity: result.similarity,
+        updatedAt: result.updatedAt,
+        containerTag: result.containerTag,
       }));
       return { content: [{ type: "text", text: JSON.stringify(formatted, null, 2) }] };
     },
@@ -159,10 +278,26 @@ export async function startMcpServer() {
       inputSchema: { content: z.string(), container: containerSchema },
     },
     async ({ content, container }) => {
+      if (container === "both") {
+        throw new Error(
+          'The "both" alias is read-only. Choose "user" or "project" when saving.',
+        );
+      }
       const auth = getAuth();
-      const tag = resolveContainer(auth, container);
-      const client = createClient(auth.apiKey, tag);
-      const result = await client.add({ content, containerTag: tag });
+      const resolved = resolveContainer(auth.tags, container);
+      const result = await auth.client.addMemory(
+        content,
+        resolved.tag,
+        {
+          type: "memory",
+          project: auth.tags.projectName,
+          sm_project_id: auth.tags.projectId,
+          ...(resolved.scope ? { sm_scope: resolved.scope } : {}),
+          sm_capture_mode: "explicit",
+          timestamp: new Date().toISOString(),
+        },
+        { entityContext: AGENT_ENTITY_CONTEXT },
+      );
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
     },
   );
@@ -175,8 +310,13 @@ export async function startMcpServer() {
     },
     async ({ query }) => {
       const auth = getAuth();
-      const client = createClient(auth.apiKey, auth.userTag);
-      const result = await client.profile({ containerTag: auth.userTag, q: query });
+      const result = await auth.client.profileScoped(
+        auth.tags.canonical,
+        auth.tags.personalReads,
+        "personal",
+        query,
+        auth.config.maxMemories,
+      );
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
     },
   );
@@ -189,9 +329,16 @@ export async function startMcpServer() {
     },
     async ({ limit, page, container }) => {
       const auth = getAuth();
-      const tag = resolveContainer(auth, container);
-      const client = createClient(auth.apiKey, tag);
-      const result = await client.documents.list({ limit, page });
+      const resolved = resolveContainer(auth.tags, container);
+      const result = resolved.scope
+        ? await auth.client.listScoped(
+            resolved.tag,
+            resolved.reads,
+            resolved.scope,
+            limit,
+            page,
+          )
+        : await auth.client.listMany(resolved.reads, limit, page);
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
     },
   );
@@ -209,9 +356,11 @@ export async function startMcpServer() {
     async ({ id, content, container }) => {
       if (!id && !content) throw new Error("Provide either id or content.");
       const auth = getAuth();
-      const tag = resolveContainer(auth, container);
-      const client = createClient(auth.apiKey, tag);
-      const result = await client.memories.forget({ containerTag: tag, id, content });
+      const resolved = resolveContainer(auth.tags, container);
+      const result = await auth.client.forgetMany(resolved.reads, {
+        id,
+        content,
+      });
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
     },
   );

--- a/src/tags.test.ts
+++ b/src/tags.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeGitRemote, sanitizeRepoName, sha256 } from "./tags.ts";
+
+describe("repository identity", () => {
+  test("normalizes equivalent HTTPS and SSH remotes", () => {
+    expect(
+      normalizeGitRemote("https://github.com/SupermemoryAI/mono.git"),
+    ).toBe("github.com/supermemoryai/mono");
+    expect(normalizeGitRemote("git@github.com:SupermemoryAI/mono.git")).toBe(
+      "github.com/supermemoryai/mono",
+    );
+  });
+
+  test("sanitizes display names without losing repository identity", () => {
+    expect(sanitizeRepoName("Codex Supermemory.js")).toBe(
+      "codex_supermemory_js",
+    );
+    expect(sha256("github.com/supermemoryai/mono")).toHaveLength(16);
+  });
+});

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -1,55 +1,519 @@
-import crypto from "node:crypto";
-import os from "node:os";
 import { execSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  readFileSync,
+  realpathSync,
+} from "node:fs";
+import { hostname, homedir, userInfo } from "node:os";
+import {
+  basename,
+  dirname,
+  join,
+  resolve,
+  sep,
+} from "node:path";
 import type { Config } from "./config.ts";
 
-function sha256(input: string): string {
-  return crypto.createHash("sha256").update(input).digest("hex").slice(0, 16);
+export function sha256(input: string): string {
+  return createHash("sha256").update(input).digest("hex").slice(0, 16);
 }
 
-function getGitEmail(): string | null {
+export function getGitRoot(directory: string): string | null {
+  const isolateWorktrees =
+    process.env.SUPERMEMORY_ISOLATE_WORKTREES === "true";
+
   try {
-    return execSync("git config user.email", {
+    if (isolateWorktrees) {
+      return (
+        execSync("git rev-parse --show-toplevel", {
+          cwd: directory,
+          encoding: "utf-8",
+          stdio: ["pipe", "pipe", "pipe"],
+        }).trim() || null
+      );
+    }
+
+    const gitCommonDir = execSync("git rev-parse --git-common-dir", {
+      cwd: directory,
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
-    }).trim() || null;
+    }).trim();
+
+    if (gitCommonDir === ".git") {
+      return (
+        execSync("git rev-parse --show-toplevel", {
+          cwd: directory,
+          encoding: "utf-8",
+          stdio: ["pipe", "pipe", "pipe"],
+        }).trim() || null
+      );
+    }
+
+    const resolvedCommonDir = resolve(directory, gitCommonDir);
+    if (
+      basename(resolvedCommonDir) === ".git" &&
+      !resolvedCommonDir.includes(`${sep}.git${sep}`)
+    ) {
+      return dirname(resolvedCommonDir);
+    }
+
+    return (
+      execSync("git rev-parse --show-toplevel", {
+        cwd: directory,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      }).trim() || null
+    );
   } catch {
     return null;
   }
 }
 
-function getGitRoot(dir: string): string | null {
+function getProjectBasePath(directory: string): string {
+  return getGitRoot(directory) || resolve(directory);
+}
+
+function getGitEmail(directory: string): string | null {
   try {
-    return execSync("git rev-parse --show-toplevel", {
-      cwd: dir,
-      encoding: "utf-8",
-      stdio: ["pipe", "pipe", "pipe"],
-    }).trim() || null;
+    return (
+      execSync("git config user.email", {
+        cwd: getProjectBasePath(directory),
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      }).trim() || null
+    );
   } catch {
     return null;
   }
 }
 
 function getMachineId(): string {
-  return `${os.hostname()}_${os.userInfo().username}`;
+  return `${hostname()}_${userInfo().username}`;
 }
 
-export function getUserTag(config: Config): string {
-  const identity =
-    config.userContainerTag ??
-    process.env.SUPERMEMORY_USER_TAG ??
-    process.env.CURSOR_USER_EMAIL ??
-    getGitEmail() ??
-    getMachineId();
+export function normalizeGitRemote(remoteUrl: string): string | null {
+  const raw = remoteUrl.trim();
+  if (!raw) return null;
 
-  return `cursor_user_${sha256(identity)}`;
+  let normalized: string;
+  if (/^[a-z][a-z\d+.-]*:\/\//i.test(raw)) {
+    try {
+      const parsed = new URL(raw);
+      normalized =
+        parsed.protocol === "file:"
+          ? `file:${decodeURIComponent(parsed.pathname)}`
+          : `${parsed.hostname.toLowerCase()}${
+              parsed.port ? `:${parsed.port}` : ""
+            }/${parsed.pathname.replace(/^\/+/, "")}`;
+    } catch {
+      normalized = raw;
+    }
+  } else {
+    const scpStyle = raw.match(/^(?:[^@/]+@)?([^:]+):(.+)$/);
+    normalized = scpStyle
+      ? `${scpStyle[1].toLowerCase()}/${scpStyle[2]}`
+      : `file:${resolve(raw)}`;
+  }
+
+  return normalized
+    .replace(/[?#].*$/, "")
+    .replace(/\/+$/, "")
+    .replace(/\.git$/i, "")
+    .replace(/\/{2,}/g, "/")
+    .toLowerCase();
 }
 
-export function getProjectTag(workspaceRoot: string, config: Config): string {
-  const identity =
-    config.projectContainerTag ??
-    process.env.SUPERMEMORY_PROJECT_TAG ??
-    (getGitRoot(workspaceRoot) || workspaceRoot);
+const repoInfoCache = new Map<
+  string,
+  { name: string | null; normalizedRemote: string | null }
+>();
 
-  return `cursor_project_${sha256(identity)}`;
+function getGitRepoInfo(directory: string): {
+  name: string | null;
+  normalizedRemote: string | null;
+} {
+  const cached = repoInfoCache.get(directory);
+  if (cached) return cached;
+
+  try {
+    const remoteUrl = execSync("git remote get-url origin", {
+      cwd: directory,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    const normalizedRemote = normalizeGitRemote(remoteUrl);
+    const displayRemote = remoteUrl.replace(/\/+$/, "").replace(/\.git$/i, "");
+    const separator = Math.max(
+      displayRemote.lastIndexOf("/"),
+      displayRemote.lastIndexOf(":"),
+    );
+    const result = {
+      name: displayRemote.slice(separator + 1) || null,
+      normalizedRemote,
+    };
+    repoInfoCache.set(directory, result);
+    return result;
+  } catch {
+    const result = { name: null, normalizedRemote: null };
+    repoInfoCache.set(directory, result);
+    return result;
+  }
+}
+
+function readJson(filePath: string): Record<string, unknown> | null {
+  try {
+    if (!existsSync(filePath)) return null;
+    return JSON.parse(readFileSync(filePath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+  } catch {
+    return null;
+  }
+}
+
+function stripJsoncComments(content: string): string {
+  let result = "";
+  let index = 0;
+  let inString = false;
+  let singleLineComment = false;
+  let multiLineComment = false;
+
+  while (index < content.length) {
+    const char = content[index];
+    const next = content[index + 1];
+
+    if (!singleLineComment && !multiLineComment && char === '"') {
+      let backslashes = 0;
+      for (
+        let cursor = index - 1;
+        cursor >= 0 && content[cursor] === "\\";
+        cursor--
+      ) {
+        backslashes++;
+      }
+      if (backslashes % 2 === 0) inString = !inString;
+      result += char;
+      index++;
+      continue;
+    }
+
+    if (inString) {
+      result += char;
+      index++;
+      continue;
+    }
+
+    if (
+      !singleLineComment &&
+      !multiLineComment &&
+      char === "/" &&
+      next === "/"
+    ) {
+      singleLineComment = true;
+      index += 2;
+      continue;
+    }
+    if (
+      !singleLineComment &&
+      !multiLineComment &&
+      char === "/" &&
+      next === "*"
+    ) {
+      multiLineComment = true;
+      index += 2;
+      continue;
+    }
+    if (singleLineComment) {
+      if (char === "\n") {
+        singleLineComment = false;
+        result += char;
+      }
+      index++;
+      continue;
+    }
+    if (multiLineComment) {
+      if (char === "*" && next === "/") {
+        multiLineComment = false;
+        index += 2;
+        continue;
+      }
+      if (char === "\n") result += char;
+      index++;
+      continue;
+    }
+
+    result += char;
+    index++;
+  }
+
+  return result.replace(/,\s*([}\]])/g, "$1");
+}
+
+function loadOpenCodeConfig(): Record<string, unknown> | null {
+  const configDir = join(homedir(), ".config", "opencode");
+  for (const filename of ["supermemory.jsonc", "supermemory.json"]) {
+    try {
+      const configPath = join(configDir, filename);
+      if (!existsSync(configPath)) continue;
+      return JSON.parse(
+        stripJsoncComments(readFileSync(configPath, "utf-8")),
+      ) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function stringValue(
+  value: unknown,
+): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function uniqueTags(
+  tags: Array<string | null | undefined>,
+): string[] {
+  return [
+    ...new Set(
+      tags.filter(
+        (tag): tag is string =>
+          typeof tag === "string" && tag.trim().length > 0,
+      ),
+    ),
+  ];
+}
+
+export function sanitizeRepoName(name: string): string {
+  const sanitized = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "");
+  return sanitized.slice(0, 95).replace(/_+$/g, "") || "unknown";
+}
+
+export function getProjectIdentity(directory: string): string {
+  const basePath = getProjectBasePath(directory);
+  const { normalizedRemote } = getGitRepoInfo(basePath);
+  const isolateWorktrees =
+    process.env.SUPERMEMORY_ISOLATE_WORKTREES === "true";
+  let localIdentity = basePath;
+  try {
+    localIdentity = realpathSync.native(basePath);
+  } catch {}
+
+  return sha256(
+    !isolateWorktrees && normalizedRemote
+      ? normalizedRemote
+      : `path:${localIdentity}`,
+  );
+}
+
+export function getProjectName(directory: string): string {
+  const basePath = getProjectBasePath(directory);
+  return getGitRepoInfo(basePath).name || basename(basePath) || "unknown";
+}
+
+export function getGeneratedRepoTag(directory: string): string {
+  const name = sanitizeRepoName(getProjectName(directory))
+    .slice(0, 72)
+    .replace(/_+$/g, "");
+  return `repo_${name || "unknown"}__${getProjectIdentity(directory)}`;
+}
+
+function getLegacyRepoTag(directory: string): string {
+  return `repo_${sanitizeRepoName(getProjectName(directory))}`;
+}
+
+function getLegacyCursorUserTags(
+  directory: string,
+  config: Config,
+): string[] {
+  const identities = uniqueTags([
+    config.userContainerTag ||
+      process.env.SUPERMEMORY_USER_TAG ||
+      process.env.CURSOR_USER_EMAIL ||
+      getGitEmail(directory) ||
+      getMachineId(),
+  ]);
+  return identities.map((identity) => `cursor_user_${sha256(identity)}`);
+}
+
+function getLegacyCursorProjectTags(
+  directory: string,
+  config: Config,
+): string[] {
+  const basePath = getProjectBasePath(directory);
+  const identities = uniqueTags([
+    config.projectContainerTag ||
+      process.env.SUPERMEMORY_PROJECT_TAG ||
+      basePath,
+  ]);
+  return identities.map((identity) => `cursor_project_${sha256(identity)}`);
+}
+
+function getLegacyClaudeTags(directory: string): {
+  personal: string[];
+  project: string[];
+  repoContainerTag: string | null;
+} {
+  const basePath = getProjectBasePath(directory);
+  const projectHash = sha256(basePath);
+  const config = readJson(
+    join(basePath, ".claude", ".supermemory-claude", "config.json"),
+  );
+  return {
+    personal: uniqueTags([
+      stringValue(config?.personalContainerTag),
+      `user_project_${projectHash}`,
+      `claudecode_project_${projectHash}`,
+    ]),
+    project: uniqueTags([
+      stringValue(config?.repoContainerTag),
+      getLegacyRepoTag(directory),
+    ]),
+    repoContainerTag: stringValue(config?.repoContainerTag),
+  };
+}
+
+function getLegacyCodexTags(directory: string): {
+  personal: string[];
+  project: string[];
+  projectContainerTag: string | null;
+} {
+  const config = readJson(join(homedir(), ".codex", "supermemory.json"));
+  const prefix = stringValue(config?.containerTagPrefix) || "codex";
+  const userIdentity =
+    getGitEmail(directory) ||
+    process.env.USER ||
+    process.env.USERNAME ||
+    hostname();
+  const userHash = sha256(userIdentity);
+  const projectHash = sha256(getProjectBasePath(directory));
+  return {
+    personal: uniqueTags([
+      stringValue(config?.userContainerTag),
+      `${prefix}_user_${userHash}`,
+      `codex_user_${userHash}`,
+    ]),
+    project: uniqueTags([
+      stringValue(config?.projectContainerTag),
+      `${prefix}_project_${projectHash}`,
+      `codex_project_${projectHash}`,
+    ]),
+    projectContainerTag: stringValue(config?.projectContainerTag),
+  };
+}
+
+function getLegacyOpenCodeTags(directory: string): {
+  personal: string[];
+  project: string[];
+  projectContainerTag: string | null;
+} {
+  const config = loadOpenCodeConfig();
+  const prefix = stringValue(config?.containerTagPrefix) || "opencode";
+  const userIdentity =
+    getGitEmail(directory) ||
+    process.env.USER ||
+    process.env.USERNAME ||
+    "anonymous";
+  const userHash = sha256(userIdentity);
+  const projectHashes = [
+    ...new Set(
+      [directory, resolve(directory), getProjectBasePath(directory)].map(
+        (value) => sha256(value),
+      ),
+    ),
+  ];
+  return {
+    personal: uniqueTags([
+      stringValue(config?.userContainerTag),
+      `${prefix}_user_${userHash}`,
+      `opencode_user_${userHash}`,
+    ]),
+    project: uniqueTags([
+      stringValue(config?.projectContainerTag),
+      ...projectHashes.flatMap((hash) => [
+        `${prefix}_project_${hash}`,
+        `opencode_project_${hash}`,
+      ]),
+    ]),
+    projectContainerTag: stringValue(config?.projectContainerTag),
+  };
+}
+
+export interface ResolvedTags {
+  canonical: string;
+  user: string;
+  project: string;
+  projectId: string;
+  projectName: string;
+  personalReads: string[];
+  projectReads: string[];
+  allReads: string[];
+  legacyCursorPersonal: string[];
+  legacyCursorProjects: string[];
+}
+
+export function getResolvedTags(
+  directory: string,
+  config: Config,
+): ResolvedTags {
+  const generated = getGeneratedRepoTag(directory);
+  const cursorPersonal = getLegacyCursorUserTags(directory, config);
+  const cursorProjects = getLegacyCursorProjectTags(directory, config);
+  const claude = getLegacyClaudeTags(directory);
+  const codex = getLegacyCodexTags(directory);
+  const opencode = getLegacyOpenCodeTags(directory);
+  const canonical =
+    config.repoContainerTag ||
+    process.env.SUPERMEMORY_REPO_TAG ||
+    claude.repoContainerTag ||
+    codex.projectContainerTag ||
+    opencode.projectContainerTag ||
+    generated;
+  const personalReads = uniqueTags([
+    canonical,
+    generated,
+    ...cursorPersonal,
+    ...claude.personal,
+    ...codex.personal,
+    ...opencode.personal,
+  ]);
+  const projectReads = uniqueTags([
+    canonical,
+    generated,
+    ...cursorProjects,
+    ...claude.project,
+    ...codex.project,
+    ...opencode.project,
+  ]);
+
+  return {
+    canonical,
+    user: canonical,
+    project: canonical,
+    projectId: getProjectIdentity(directory),
+    projectName: getProjectName(directory),
+    personalReads,
+    projectReads,
+    allReads: uniqueTags([...personalReads, ...projectReads]),
+    legacyCursorPersonal: cursorPersonal,
+    legacyCursorProjects: cursorProjects,
+  };
+}
+
+/** Backwards-compatible aliases for callers that have not moved to ResolvedTags. */
+export function getUserTag(config: Config, directory = process.cwd()): string {
+  return getResolvedTags(directory, config).canonical;
+}
+
+export function getProjectTag(
+  workspaceRoot: string,
+  config: Config,
+): string {
+  return getResolvedTags(workspaceRoot, config).canonical;
 }


### PR DESCRIPTION
Unifies Cursor memory with the shared Agents repository container while preserving legacy reads. Updates MCP/session capture, source metadata, docs, tests, and bumps the package to 1.0.2.

Tests: typecheck, unit tests, and build.
